### PR TITLE
Consolidate open Dependabot updates (HTTP compat, test compat, docs actions)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,8 +14,8 @@ jobs:
       PYTHON: ""
       DATADEPS_ALWAYS_ACCEPT: true
     steps:
-      - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
-      - uses: julia-actions/setup-julia@5c9647d97b78a5debe5164e9eec09d653d29bd71 # v2.6.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3.0.2
         with:
           version: '1'
       - name: Install dependencies

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
-HTTP = "1, 2.6"
+HTTP = "1, 2"
 JSON = "0.21, 1"
 julia = "1.12"
 

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
-HTTP = "1"
+HTTP = "1, 2.6"
 JSON = "0.21, 1"
 julia = "1.12"
 

--- a/src/Pasteee.jl
+++ b/src/Pasteee.jl
@@ -95,9 +95,8 @@ Retrieve all pastes, organized in pages containing `perpage` entries.
 Returns entries in page number `page`.
 """
 function pastes(appkey::AbstractString; perpage::Int = 25, page::Int = 1)
-    headers = ["X-Auth-Token" => appkey, "Content-Type" => "application/json"]
-    data = Dict("perpage" => perpage, "page" => page)
-    response = HTTP.get("https://api.paste.ee/v1/pastes", headers, JSON.json(data))
+    headers = ["X-Auth-Token" => appkey]
+    response = HTTP.get("https://api.paste.ee/v1/pastes?perpage=$perpage&page=$page", headers)
     return JSON.parse(String(response.body))
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,3 +2,6 @@
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Pasteee = "f468650b-ff2f-47f6-a837-e130848f4551"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+HTTP = "2.6.5"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,3 @@
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Pasteee = "f468650b-ff2f-47f6-a837-e130848f4551"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[compat]
-HTTP = "2.6.5"


### PR DESCRIPTION
Consolidates the three open Dependabot PRs into a single change; the originals were closed in favor of this one.

- From #7: widen `HTTP` compat in `Project.toml` from `"1"` to `"1, 2"` (Dependabot proposed `"1, 2.6"`; widened to all 2.x per review).
- From #3: bump the docs workflow action pins to `actions/checkout@3d3c42e5` (v7.0.1) and `julia-actions/setup-julia@fa02766e` (v3.0.2), matching the pins already used in `ci.yml`.
- #4 was stale — it targeted an older master (`HTTP = "0.9"`, `JSON = "0.21"`); current master already allows HTTP 1.x and JSON 1.x, so its changes are superseded. Its `test/Project.toml` compat addition was initially carried over, then dropped per review (test compat entries for main deps are not wanted; the main `[compat]` governs the test environment).
- Compatibility fix required by the HTTP update: HTTP.jl 2.x removed `HTTP.get(url, headers, body)`, so `pastes()` now sends `perpage`/`page` as query parameters (the documented paste.ee form) instead of a JSON body on a GET. Works on both HTTP 1.x and 2.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QiqPwwZLXWyUGJyNdaQ1z