### PR TITLE
Docs: deploy with GITHUB_TOKEN instead of broken SSH deploy key

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,10 @@ on:
     tags: [v*]
   pull_request:
 
+permissions:
+  contents: write
+  statuses: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -23,6 +27,5 @@ jobs:
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
           PASTEEE_APPKEY: ${{ secrets.PASTEEE_APPKEY }}
         run: julia --project=docs/ docs/make.jl


### PR DESCRIPTION
Fixes the Documentation workflow failure on every push to master.

The docs build succeeds, but the `deploydocs` step fails with `git@github.com: Permission denied (publickey)` — the `DOCUMENTER_KEY` secret no longer matches a deploy key with write access on this repo. This has been failing on all master pushes since at least Aug 23 and never shows on PRs, because the deploy step only runs on pushes to master.

Changes:
- Remove `DOCUMENTER_KEY` from the deploy step's env, so Documenter falls back to `GITHUB_TOKEN` authentication (already provided) and pushes `gh-pages` over HTTPS.
- Add an explicit `permissions` block: `contents: write` for the `gh-pages` push, `statuses: write` for the commit status Documenter posts.

Alternative, if you prefer keeping SSH deploys: regenerate the keypair with `DocumenterTools.genkeys(user="cossio", repo="Pasteee.jl")`, install the public half as a deploy key with write access, and update the `DOCUMENTER_KEY` secret — then this change isn't needed.

Note: the deploy fix itself can only be fully verified after this merges, since the deploy step runs only on master pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QiqPwwZLXWyUGJyNdaQ1z

---
_Generated by [Claude Code](https://claude.ai/code/session_014QiqPwwZLXWyUGJyNdaQ1z)_